### PR TITLE
Add airport autocomplete

### DIFF
--- a/HelloWorld/Model/Airport.swift
+++ b/HelloWorld/Model/Airport.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftUI
+
+struct Airport: Identifiable {
+    let id = UUID()
+    let code: String
+    let name: String
+    let city: String?
+    let country: String?
+}
+
+struct AirportResponse: Decodable {
+    let metaAirports: [String: AirportDetails]
+}
+
+struct AirportDetails: Decodable {
+    let name: String?
+    let city: String?
+    let country: String?
+}


### PR DESCRIPTION
## Summary
- create `Airport` model for metaAirports API
- fetch airport list in `FlightSearchViewModel`
- show autocomplete suggestions for origin and destination fields

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc HelloWorld/Views/SearchView.swift -typecheck` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687f858bbdd48321ac1b0b27024e9eb3