### PR TITLE
Improve airport suggestions

### DIFF
--- a/HelloWorld/Model/Airport.swift
+++ b/HelloWorld/Model/Airport.swift
@@ -12,6 +12,7 @@ struct Airport: Identifiable {
 struct RefDataResponse: Decodable {
     let airports: [String: AirportDetails]?
     let metaAirports: [String: [String]]
+    let airportNames: [String: String]?
 }
 
 struct AirportDetails: Decodable {

--- a/HelloWorld/ViewModel/FlightSearchViewModel.swift
+++ b/HelloWorld/ViewModel/FlightSearchViewModel.swift
@@ -21,20 +21,15 @@ class FlightSearchViewModel: ObservableObject {
             }
 
             var list: [Airport] = []
-            if let details = decoded.airports {
-                for code in codes {
-                    let info = details[code]
-                    list.append(
-                        Airport(code: code,
-                                name: info?.name ?? code,
-                                city: info?.city,
-                                country: info?.country)
-                    )
-                }
-            } else {
-                for code in codes {
-                    list.append(Airport(code: code, name: code, city: nil, country: nil))
-                }
+            for code in codes {
+                let info = decoded.airports?[code]
+                let resolvedName = decoded.airportNames?[code] ?? info?.name ?? code
+                list.append(
+                    Airport(code: code,
+                            name: resolvedName,
+                            city: info?.city,
+                            country: info?.country)
+                )
             }
 
             airports = list.sorted { $0.code < $1.code }

--- a/HelloWorld/Views/SearchView.swift
+++ b/HelloWorld/Views/SearchView.swift
@@ -99,8 +99,15 @@ struct SearchView: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(airports) { airport in
                     HStack {
-                        Text(label(for: airport))
-                            .font(.subheadline)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(airport.code)
+                                .font(.subheadline)
+                                .bold()
+                            Text(airport.name)
+                                .font(.caption)
+                                .italic()
+                                .foregroundColor(.secondary)
+                        }
                         Spacer()
                     }
                     .padding(6)
@@ -115,16 +122,6 @@ struct SearchView: View {
         .frame(maxHeight: 120)
     }
 
-    private func label(for airport: Airport) -> String {
-        var text = "\(airport.code) - \(airport.name)"
-        if let city = airport.city {
-            text += ", \(city)"
-        }
-        if let country = airport.country {
-            text += " - \(country)"
-        }
-        return text
-    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- parse airportNames from API response
- use description names in search suggestions
- display airport codes in bold with italic name below

## Testing
- `swift build` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6882771fec548321a0b0174b408f1f7b